### PR TITLE
Update Go to version 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22 as builder
+FROM docker.io/library/golang:1.25 as builder
 
 WORKDIR /app
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/Moulick/Kinesis2Elastic/v2
 
-go 1.22.2
-toolchain go1.24.1
+go 1.25
 
 require (
 	github.com/Depado/ginprom v1.8.1


### PR DESCRIPTION
## Summary
- Updates Go version from 1.22.2 to 1.25 in go.mod
- Updates Dockerfile base image from golang:1.22 to golang:1.25  
- Removes toolchain specification from go.mod as it's no longer needed

## Test plan
- [ ] Verify build passes with new Go version
- [ ] Check that all existing functionality works correctly
- [ ] Confirm Docker image builds successfully